### PR TITLE
Задача 11

### DIFF
--- a/src/Task11.java
+++ b/src/Task11.java
@@ -1,0 +1,28 @@
+import java.util.Scanner;
+
+public class Task11 {
+    public static void main(String[] args) {
+        Scanner scan = new Scanner(System.in);
+        System.out.println("Введите слово");
+        String text = scan.next();
+        String regularLanguage = "[a-c]*";
+        boolean textCont = text.matches(regularLanguage);
+        boolean textContB = text.contains("bb");
+        two:if (textCont && !textContB) {
+            boolean textContains;
+            for (int i = 0; i < text.length(); i++) {
+                for (int a = i + 1; a <= text.length() / 3; a++) {
+                    String regular = text.substring(i, a).concat(text.substring(i, a)).concat(text.substring(i, a));
+                    textContains = text.contains(regular);
+                    if (textContains) {
+                        System.out.println("Слово не принадлежит языку Мумба-Юмба");
+                        break two;
+                    }
+                }
+            }
+            System.out.println("Слово принадлежит языку Мумба-Юмба");
+        } else {
+            System.out.println("Слово не принадлежит языку Мумба-Юмба");
+        }
+    }
+}


### PR DESCRIPTION
Слова в языке Мумба-Юмба могут состоять только из букв
a, b, c, и при этом:
■ никогда не содержат двух букв b подряд;
■ ни в одном слове никогда не встречается три одинаковых
подслова подряд. Например, по этому правилу, в язык
Мумба-Юмба не могут входить слова aaa (так как три
раза подряд содержит подслово a), ababab (так как три
раза подряд содержит подслово ab), aabcabcabca (три
раза подряд содержит подслово abc).
Все слова, удовлетворяющие вышеописанным правилам,
входят в язык Мумба-Юмба.
Напишите программу, которая по данному слову (введеного с клавиатуры) определит, принадлежит ли оно этому
языку.